### PR TITLE
Execute script script

### DIFF
--- a/bin/script
+++ b/bin/script
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+service=$1
+script=$2
+
+help() {
+    echo "script [service] [script]"
+    echo
+    echo To execute a script on a service the service must be running.
+    echo The script to execute is 
+}
+
+case "$service" in
+"" | "--help" | "-h")
+    help
+    ;;
+"redis")
+    # hack a snazzy redis prompt despite it being a stock image
+    docker-compose exec --env SUDO_USER=x --env SUDO_PS1=x --env PS1="{^_^} redis\n      \w % " redis bash
+    ;;
+"website")
+    docker-compose exec --env SUDO_USER=x --env SUDO_PS1=x --env PS1="{^_^} website\n      \w % " website /bin/bash
+    ;;
+"rails")
+    docker-compose exec website /bin/bash '-c' 'bundle exec rails console'
+    ;;
+"tmux")
+    docker-compose exec website overmind 'c' 'server'
+    ;;
+"mysql")
+    docker-compose exec mysql mysql -ppassword
+    ;;
+"redis-cli")
+    docker-compose exec redis redis-cli
+    ;;
+"tooling-invoker")
+    docker-compose exec --env PS1="{^_^} tooling-invoker\n      \w % " tooling-invoker /bin/bash
+    ;;
+"tooling-orchestrator")
+    docker-compose exec --env PS1="{^_^} tooling-orchestrator\n      \w % " tooling-orchestrator /bin/sh
+    ;;
+esac
+
+
+
+handle_container_error() {
+    result=$?
+    if [ $result -ne 0 ]
+    then
+        echo
+        echo "Hint: If you're told the 'container is not running' you'll need to start it first:"
+        echo
+        echo "    % docker-compose up -d website"
+        exit $result
+    fi
+}

--- a/bin/script
+++ b/bin/script
@@ -7,41 +7,31 @@ help() {
     echo "script [service] [script]"
     echo
     echo To execute a script on a service the service must be running.
-    echo The script to execute is 
+    echo These are the services and scripts that can be run:
+
+    find ./scripts -maxdepth 1 -mindepth 1 -type d | sort | while read script_dir; do
+        echo
+        echo $(basename $script_dir)
+
+        find $script_dir -maxdepth 1 -mindepth 1 -type f | sort | while read script_file; do
+            echo "  - $(basename $script_file)"
+        done
+    done
 }
 
-case "$service" in
-"" | "--help" | "-h")
-    help
-    ;;
-"redis")
-    # hack a snazzy redis prompt despite it being a stock image
-    docker-compose exec --env SUDO_USER=x --env SUDO_PS1=x --env PS1="{^_^} redis\n      \w % " redis bash
-    ;;
-"website")
-    docker-compose exec --env SUDO_USER=x --env SUDO_PS1=x --env PS1="{^_^} website\n      \w % " website /bin/bash
-    ;;
-"rails")
-    docker-compose exec website /bin/bash '-c' 'bundle exec rails console'
-    ;;
-"tmux")
-    docker-compose exec website overmind 'c' 'server'
-    ;;
-"mysql")
-    docker-compose exec mysql mysql -ppassword
-    ;;
-"redis-cli")
-    docker-compose exec redis redis-cli
-    ;;
-"tooling-invoker")
-    docker-compose exec --env PS1="{^_^} tooling-invoker\n      \w % " tooling-invoker /bin/bash
-    ;;
-"tooling-orchestrator")
-    docker-compose exec --env PS1="{^_^} tooling-orchestrator\n      \w % " tooling-orchestrator /bin/sh
-    ;;
-esac
+run_script() {
+    script_path="./scripts/$service/$script"
 
+    if [ ! -f $script_path ]; then
+        echo "Could not find the '$script' script for the '$service' service."
+        exit 1
+    fi
 
+    # Excute the script
+    $script_path
+
+    handle_container_error
+}
 
 handle_container_error() {
     result=$?
@@ -54,3 +44,12 @@ handle_container_error() {
         exit $result
     fi
 }
+
+case "$service" in
+"" | "--help" | "-h")
+    help
+    ;;
+*)
+    run_script
+    ;;
+esac

--- a/scripts/tooling-invoker/test
+++ b/scripts/tooling-invoker/test
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    tooling-invoker \
+    bundle exec rake test

--- a/scripts/website/lint
+++ b/scripts/website/lint
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    website \
+    bundle exec rubocop --except Metrics

--- a/scripts/website/run-js-tests
+++ b/scripts/website/run-js-tests
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    website \
+    yarn test

--- a/scripts/website/run-system-tests
+++ b/scripts/website/run-system-tests
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    -e EXERCISM_ENV=test \
+    website \
+    bundle exec rake test:system

--- a/scripts/website/run-tests
+++ b/scripts/website/run-tests
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    -e EXERCISM_ENV=test \
+    website \
+    bundle exec rake test

--- a/scripts/website/seed
+++ b/scripts/website/seed
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker-compose exec \
+    -e EXERCISM_DOCKER=true \
+    -e EXERCISM_ENV=test \
+    website \
+    bin/rails db:seed


### PR DESCRIPTION
This PR adds supports for a `./bin/script` script which can, well, run scripts :) It can do so as follows: `./bin/script website lint`.

The original idea was that it would shell out to scripts that are found in the respective service repository's directory. The main disadvantage of this is that it requires the directory to be checked out. It would not be possible to run any of the scripts without having the directory checked out, which can make it a little more troublesome for people to get started with. In this PR I've moved the scripts into this repo, but I could easily move them back if needed. 

Let me know what you think.