### PR TITLE
Fix shebangs of bash scripts in `bin`

### DIFF
--- a/bin/rubocop-quick
+++ b/bin/rubocop-quick
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs bundle exec rubocop --except Metrics --auto-correct --format quiet --force-exclusion Gemfile && \
 git diff --name-status --staged | grep '^[MA]' | grep -o '\s\+.*rb' | xargs git add

--- a/bin/script
+++ b/bin/script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 service=$1
 script=$2

--- a/bin/shell
+++ b/bin/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 service=$1
 

--- a/bin/start
+++ b/bin/start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 for arg in "$@"


### PR DESCRIPTION
Not every system provides a `/bin/bash`, mine wouldn't even provide `/usr/bin/bash`, but `/usr/bin/env` is available pretty much everywhere.

Therefore I changed all shebangs which do currently not use `/usr/bin/env` but seem to be intended to be run from outside of docker to use `/usr/bin/env` to make them more portable.