### PR TITLE
Incorrect EXERCISM_DEV_ENV_DIR caused docker run to fail.

### DIFF
--- a/stack.default.yml
+++ b/stack.default.yml
@@ -35,7 +35,7 @@ configure:
 
   tooling-invoker:
     environment:
-      EXERCISM_DEV_ENV_DIR: "<%= File.expand_path(__dir__) %>:/tmp"
+      EXERCISM_DEV_ENV_DIR: "<%= File.expand_path(__dir__) %>"
 
   # ruby-test-runner:
   #   build: true


### PR DESCRIPTION
The `:/tmp` at the end of the value for EXERCISM_DEV_ENV_DIR caused
docker run from the tooling-invoker to fail with the error:

`docker: Error response from daemon: invalid mode: /mnt/exercism-iteration.
See 'docker run --help'.`

(c.f. https://github.com/exercism/tooling-invoker/issues/30)