### PR TITLE
Fix default port mapping

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -53,8 +53,8 @@ services:
       - OVERMIND_SOCKET=/usr/src/app/tmp/overmind.sock
     ports:
       - 3020:3020
-      - 3035:3035
-      - 3334:3334
+      - 9999:3035
+      - 9998:3334
     volumes:
       - ../v3-website:/usr/src/app
       - "./tmp/exercism-tooling-jobs:/tmp/exercism-tooling-jobs"


### PR DESCRIPTION
In https://github.com/exercism/development-environment/blob/master/stack.default.yml, this is set correctly, but the ports aren't transferred to the generated docker file. I decided to just put the ports as the default for now as it's the right set up to get the WebSockets ports working.