### PR TITLE
Rename v3-website to website

### DIFF
--- a/bin/script
+++ b/bin/script
@@ -16,7 +16,7 @@ help() {
 
 detect_and_print_available_scripts() {
     # iterate over the directories in the parent directory, which should be
-    # exercism repositories like v3-website, tooling-orchestrator, etc.
+    # exercism repositories like website, tooling-orchestrator, etc.
     find .. -maxdepth 1 -mindepth 1 -type d | sort | while read repo_dir; do
         docker_scripts_dir="$repo_dir/scripts/docker"
 
@@ -29,7 +29,7 @@ detect_and_print_available_scripts() {
         # iterate over all the files in the repo's scripts/docker directory
         find $docker_scripts_dir -maxdepth 1 -mindepth 1 -type f | sort | while read script_file; do
             if [ $print_service ]; then
-                echo "- $(basename ${repo_dir/v3-website/website})"
+                echo "- $(basename ${repo_dir})"
                 unset print_service
             fi
 
@@ -44,14 +44,7 @@ run_script() {
         exit
     fi
 
-    # The v3-website directory is different from the container name
-    if [ $service = "website" ]; then
-        service_directory="v3-website"
-    else
-        service_directory=$service
-    fi
-
-    script_path="../$service_directory/scripts/docker/$script"
+    script_path="../$service/scripts/docker/$script"
 
     if [ ! -f $script_path ]; then
         echo "Could not find the '$script' script for the '$service' service."

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -38,7 +38,7 @@ services:
     image: exercism/website
     stop_grace_period: 1s
     build:
-      context: ../v3-website
+      context: ../website
       dockerfile: dev.Dockerfile
     depends_on:
       - mysql
@@ -56,7 +56,7 @@ services:
       - 9999:3035
       - 9998:3334
     volumes:
-      - ../v3-website:/usr/src/app
+      - ../website:/usr/src/app
       - "./tmp/exercism:/tmp/exercism"
       - /usr/src/app/node_modules
       - type: tmpfs

--- a/docs/common_workflows.md
+++ b/docs/common_workflows.md
@@ -6,20 +6,20 @@
 <root>
 ├── development-environment
 ├── <Any other v3 repos you may be working with>
-└── v3-website
+└── website
 ```
 
 ## Git workflow to working from a fork
 
-### Cloning `exercism/v3-website` and maintaining your `fork`
+### Cloning `exercism/website` and maintaining your `fork`
 
 ```text
 > cd <root>
-> git clone https://github.com/exercism/v3-website.git
-> cd v3-website
+> git clone https://github.com/exercism/website.git
+> cd website
 ```
 
-After a pull request is opened against `exercism/v3-website`, the remote fork's branch can be checked out [following this guide][github-mod-inactive-pr-local].  After making a commit, you can't `git push` to the `exercism`'s repo, but you can to your own fork.
+After a pull request is opened against `exercism/website`, the remote fork's branch can be checked out [following this guide][github-mod-inactive-pr-local]. After making a commit, you can't `git push` to the `exercism`'s repo, but you can to your own fork.
 
 ```text
 > git push <remote-name> HEAD:<remote-branch-name>
@@ -29,14 +29,14 @@ After a pull request is opened against `exercism/v3-website`, the remote fork's 
 
 ```text
 > cd <root>
-> git clone <your v3-website fork> v3-website 
+> git clone <your website fork> website
 ```
 
 Then when making commits you can easily push the commit to the origin (your fork).
 
 ## Running tests
 
-Now when you start the development environment, it will use your `v3-website` repo as the source for the rails application. When the development environment is running, enter the website's running docker container to run tests.
+Now when you start the development environment, it will use your `website` repo as the source for the rails application. When the development environment is running, enter the website's running docker container to run tests.
 
 ```text
 # Open a terminal to the running website container:
@@ -56,4 +56,5 @@ If you don't need a persistent terminal in the container, you can also use these
 > ./bin/script website run-tests            # Run the Rails tests
 > ./bin/script website run-system-tests     # Run the Capybara tests
 ```
+
 [github-mod-inactive-pr-local]: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally


### PR DESCRIPTION
Now that the v3-website repo has been renamed to just website, we should update our references. This even allows us to remove some code :)

CC @verdammelt @ekingery @BethanyG @SaschaMann @TheLostLambda